### PR TITLE
Fix background flicker when sheet is at top position

### DIFF
--- a/Sheets/SheetView.swift
+++ b/Sheets/SheetView.swift
@@ -448,9 +448,15 @@ extension SheetView {
             // (dimmed -> clear). It needs to be reversed when animating back to dimmed.
             animator.isReversed = targetPositon == topPosition
 
-            let timingParameters = UISpringTimingParameters(dampingRatio: 0.9, initialVelocity: CGVector(dx: 0, dy: springVelocity))
-            let durationFactor = CGFloat(duration / animator.duration)
-            animator.continueAnimation(withTimingParameters: timingParameters, durationFactor: durationFactor)
+            let completedValue: CGFloat = animator.isReversed ? 1 : 0
+            if !animator.fractionComplete.isEqual(to: completedValue) {
+                let timingParameters = UISpringTimingParameters(
+                    dampingRatio: 0.9,
+                    initialVelocity: CGVector(dx: 0, dy: springVelocity)
+                )
+                let durationFactor = CGFloat(duration / animator.duration)
+                animator.continueAnimation(withTimingParameters: timingParameters, durationFactor: durationFactor)
+            }
         }
     }
 


### PR DESCRIPTION
This fixes the background flicker when you pan up while the sheet is already at the top.