### PR TITLE
Fix background tap gesture not dismissing the sheet

### DIFF
--- a/Sheets/PresentationAnimation/SheetAnimationController.swift
+++ b/Sheets/PresentationAnimation/SheetAnimationController.swift
@@ -41,6 +41,8 @@ extension SheetAnimationController: UIViewControllerAnimatedTransitioning {
 
         if isPresenting {
             sheetViewController.sheetView?.contentView.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.bounds.height)
+        } else {
+            sheetViewController.backgroundDimmingAnimator.stopAnimation(true)
         }
 
         UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: {

--- a/Sheets/SheetView.swift
+++ b/Sheets/SheetView.swift
@@ -172,7 +172,8 @@ class SheetView: UIView {
     // MARK: UIView
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        if contentView.frame.inset(by: contentTouchInsets).contains(point) {
+        let handleViewPoint = convert(point, to: contentView)
+        if contentView.frame.contains(point) || handleView.frame.contains(handleViewPoint) {
             return true
         }
 
@@ -188,8 +189,11 @@ class SheetView: UIView {
         if contentView.frame.contains(point) {
             let contentViewPoint = convert(point, to: contentView)
             return contentView.hitTest(contentViewPoint, with: event)
-        } else if contentView.frame.inset(by: contentTouchInsets).contains(point) {
-            // Extend the contentView hitTest to include the handle view when the handle is above the content view.
+        }
+
+        // Extend the handleView's tappable area slightly larger than its small frame.
+        let handleViewPoint = convert(point, to: contentView)
+        if handleView.frame.insetBy(dx: -16, dy: -16).contains(handleViewPoint) {
             return handleView
         }
 

--- a/Sheets/SheetViewController.swift
+++ b/Sheets/SheetViewController.swift
@@ -59,8 +59,8 @@ public class SheetViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        backgroundView.isUserInteractionEnabled = true
-        backgroundView.addGestureRecognizer(tapGestureRecognizer)
+        view.addGestureRecognizer(tapGestureRecognizer)
+        backgroundView.isUserInteractionEnabled = false
 
         backgroundDimmingAnimator.addAnimations { [weak self] in
             self?.backgroundView.clearBackground()
@@ -130,6 +130,6 @@ extension SheetViewController: SheetViewDelegate {
 
 extension SheetViewController: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        return touch.view == backgroundView
+        return touch.view == view
     }
 }

--- a/SheetsTests/SheetViewControllerTests.swift
+++ b/SheetsTests/SheetViewControllerTests.swift
@@ -29,8 +29,8 @@ class SheetViewControllerTests: XCTestCase {
     func testViewDidLoadAddsTheBackgroundView() {
         subject.viewDidLoad()
 
-        XCTAssertTrue(subject.backgroundView.isUserInteractionEnabled)
-        XCTAssertEqual(subject.backgroundView.gestureRecognizers, [subject.tapGestureRecognizer])
+        XCTAssertTrue(subject.view.isUserInteractionEnabled)
+        XCTAssertEqual(subject.view.gestureRecognizers, [subject.tapGestureRecognizer])
         XCTAssertTrue(subject.tapGestureRecognizer.delegate === subject)
         XCTAssertTrue(subject.view.subviews.contains(subject.backgroundView))
     }


### PR DESCRIPTION
This fixes the issue where after you drag the sheet you can no longer tap on the dimmed view to dismiss it.