### PR TITLE
Fix sheet handle still shows when closed

### DIFF
--- a/Sheets/SheetView.swift
+++ b/Sheets/SheetView.swift
@@ -115,13 +115,6 @@ public class SheetView: UIView {
     /// to calculate how far up/down the sheet should be adjusted.
     var translationAtInteractionStart: CGPoint = .zero
 
-    /// UIEdgeInsets for the contentView which includes the handle view's position.
-    private var contentTouchInsets: UIEdgeInsets {
-        guard let handleConfiguration = configuration.handleConfiguration else { return .zero }
-        let yInset = min(-handleConfiguration.topInset - 16, 0)
-        return UIEdgeInsets(top: yInset, left: 0, bottom: 0, right: 0)
-    }
-
     // MARK: Initialization
 
     /// Initialize a `SheetView`.
@@ -281,8 +274,13 @@ public class SheetView: UIView {
         ]
         fittingSizeHeightConstraint.priority = .init(999)
 
+        let handleInset = configuration.handleConfiguration?.topInset ?? 0
         closedConstraints = [
-            contentView.topAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            // Extend the constraint constant `handleInset` points below the bottomAnchor, so that
+            // the handle isn't seen when the sheet is in the closed position. `handleInset` can be
+            // negative if the handle is in the sheet (as opposed to above it), so in that case, the
+            // constraint constant should just be zero
+            contentView.topAnchor.constraint(equalTo: bottomAnchor, constant: max(handleInset, 0)),
         ]
     }
 

--- a/SheetsTests/SheetViewTests.swift
+++ b/SheetsTests/SheetViewTests.swift
@@ -10,4 +10,21 @@ class SheetViewTests: XCTestCase {
 
         subject = SheetView(view: UIView(), configuration: SheetConfiguration())
     }
+
+    /// The sheet closed constraints account for moving the sheet offscreen even if the handle is above the sheet.
+    func testClosedConstraintsHideHandle() {
+        // No handle.
+        XCTAssertEqual(subject.closedConstraints.count, 1)
+        XCTAssertEqual(subject.closedConstraints.first?.constant, 0)
+
+        // Handle above the sheet.
+        subject = SheetView(view: UIView(), configuration: SheetConfiguration(handleConfiguration: SheetHandleConfiguration(topInset: 16)))
+        XCTAssertEqual(subject.closedConstraints.count, 1)
+        XCTAssertEqual(subject.closedConstraints.first?.constant, 16)
+
+        // Handle in the sheet.
+        subject = SheetView(view: UIView(), configuration: SheetConfiguration(handleConfiguration: SheetHandleConfiguration(topInset: -16)))
+        XCTAssertEqual(subject.closedConstraints.count, 1)
+        XCTAssertEqual(subject.closedConstraints.first?.constant, 0)
+    }
 }


### PR DESCRIPTION
This fixes the handle still showing when sliding the sheet into the closed position before the view is dismissed.