### PR TITLE
Fix sheet interaction with in-call status bar

### DIFF
--- a/Sheets.xcodeproj/project.pbxproj
+++ b/Sheets.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C94A275F21B1C4420059C398 /* SheetHandleConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94A275E21B1C4420059C398 /* SheetHandleConfigurationTests.swift */; };
 		C94A276221B1C4C80059C398 /* BackwardStackSheetTransitionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94A276121B1C4C80059C398 /* BackwardStackSheetTransitionManagerTests.swift */; };
 		C94A276421B1C6A90059C398 /* ForwardStackSheetTarnsitionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94A276321B1C6A90059C398 /* ForwardStackSheetTarnsitionManager.swift */; };
+		C96B52D324AA2328006998BE /* SheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96B52D224AA2328006998BE /* SheetPresentationController.swift */; };
 		C99A872A21AEE6F700F8E7D2 /* ForwardStackSheetTransitionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99A872921AEE6F700F8E7D2 /* ForwardStackSheetTransitionManager.swift */; };
 		C99A872C21AEF0F200F8E7D2 /* SheetTransitionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99A872B21AEF0F200F8E7D2 /* SheetTransitionManager.swift */; };
 		C99A872E21AEF11700F8E7D2 /* BackwardStackSheetTransitionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99A872D21AEF11700F8E7D2 /* BackwardStackSheetTransitionManager.swift */; };
@@ -68,6 +69,7 @@
 		C94A275E21B1C4420059C398 /* SheetHandleConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetHandleConfigurationTests.swift; sourceTree = "<group>"; };
 		C94A276121B1C4C80059C398 /* BackwardStackSheetTransitionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackwardStackSheetTransitionManagerTests.swift; sourceTree = "<group>"; };
 		C94A276321B1C6A90059C398 /* ForwardStackSheetTarnsitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardStackSheetTarnsitionManager.swift; sourceTree = "<group>"; };
+		C96B52D224AA2328006998BE /* SheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetPresentationController.swift; sourceTree = "<group>"; };
 		C99A872921AEE6F700F8E7D2 /* ForwardStackSheetTransitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardStackSheetTransitionManager.swift; sourceTree = "<group>"; };
 		C99A872B21AEF0F200F8E7D2 /* SheetTransitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetTransitionManager.swift; sourceTree = "<group>"; };
 		C99A872D21AEF11700F8E7D2 /* BackwardStackSheetTransitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackwardStackSheetTransitionManager.swift; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				C9496FB7219B76E0003753AC /* SheetAnimationController.swift */,
+				C96B52D224AA2328006998BE /* SheetPresentationController.swift */,
 				C9496FB9219B7736003753AC /* SheetTransitioningDelegate.swift */,
 			);
 			path = PresentationAnimation;
@@ -412,6 +415,7 @@
 				C9ADF9A9219F0FD200F7D4EC /* BlurredSheetBackgroundView.swift in Sources */,
 				C9496FBC219B788A003753AC /* SheetView.swift in Sources */,
 				C9C2837F219F32FB006E2C2B /* SheetItem.swift in Sources */,
+				C96B52D324AA2328006998BE /* SheetPresentationController.swift in Sources */,
 				C9D1F68721B07D2300D8FA0C /* SheetHandleConfiguration.swift in Sources */,
 				C9496FC0219B78C4003753AC /* SheetPosition.swift in Sources */,
 				C9ADF9A7219F0FBF00F7D4EC /* DimmingSheetBackgroundView.swift in Sources */,

--- a/Sheets/PresentationAnimation/SheetAnimationController.swift
+++ b/Sheets/PresentationAnimation/SheetAnimationController.swift
@@ -37,6 +37,10 @@ extension SheetAnimationController: UIViewControllerAnimatedTransitioning {
             return
         }
 
+        // Setting the sheet's frame here fixes an issue when the sheet is presented with the
+        // pre-iOS 13 in-call status bar being shown where the bottom of the sheet extends 20pt
+        // below the bottom the screen.
+        sheetViewController.view.frame = transitionContext.containerView.bounds
         transitionContext.containerView.addSubview(sheetViewController.view)
 
         if isPresenting {

--- a/Sheets/PresentationAnimation/SheetPresentationController.swift
+++ b/Sheets/PresentationAnimation/SheetPresentationController.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+/// `UIPresentationController` for presenting/dismissing the `SheetViewController`.
+///
+class SheetPresentationController: UIPresentationController {
+
+    // MARK: Initialization
+
+    /// Initialize a `SheetPresentationController`.
+    ///
+    /// - Parameters:
+    ///   - presentedViewController: The view controller being presented modally.
+    ///   - presenting: The view controller whose content represents the starting point of the transition.
+    ///
+    override init(presentedViewController: UIViewController, presenting: UIViewController?) {
+        super.init(presentedViewController: presentedViewController, presenting: presenting)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillChangeStatusBarFrame(notification:)),
+            name: UIApplication.willChangeStatusBarFrameNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleWillChangeStatusBarFrame(notification: Notification) {
+        // Pre-iOS 13, when the in-call status bar appears UIKit adjusts the containerView's frame
+        // down by 20pt to prevent the status bar from obscuring any content. However, when it's
+        // removed, it does not adjust it back. This leaves an additional 20pt gap between the top
+        // of the screen and the top of the view. When a sheet is presented with a dimmed
+        // background, this results in the dimmed background view being 20pt from the top of the
+        // screen. Instead of seeing the dimmed background behind the status bar, the background of
+        // the view controller below the sheet shows through.
+        //
+        // This fixes that by resetting the container view's frame to match its window, timed
+        // roughly to match the status bar animation.
+        if let containerView = containerView, let window = containerView.window {
+            UIView.animate(withDuration: 0.33) {
+                containerView.frame = window.frame
+            }
+        }
+    }
+}

--- a/Sheets/PresentationAnimation/SheetTransitioningDelegate.swift
+++ b/Sheets/PresentationAnimation/SheetTransitioningDelegate.swift
@@ -33,4 +33,12 @@ extension SheetTransitioningDelegate: UIViewControllerTransitioningDelegate {
         guard dismissed is SheetViewController else { return nil }
         return SheetAnimationController(duration: duration, isPresenting: false)
     }
+
+    public func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
+        return SheetPresentationController(presentedViewController: presented, presenting: presenting)
+    }
 }

--- a/Sheets/SheetView.swift
+++ b/Sheets/SheetView.swift
@@ -89,6 +89,15 @@ public class SheetView: UIView {
 
     // MARK: UIView
 
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // Workaround for in-call status bar issues (pre-iOS 13). When the in-call status bar
+        // appears or disappears, the sheet view is resized to fit below the status bar. When this
+        // occurs, the layout manager needs to adjust the sheet accordingly.
+        layoutManager.sheetBounds = bounds
+    }
+
     override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let contentViewPoint = contentView.convert(point, from: self)
         if contentView.point(inside: contentViewPoint, with: event) {
@@ -101,7 +110,7 @@ public class SheetView: UIView {
 
     override public func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
-        layoutManager.safeAreaInsets = safeAreaInsets
+        layoutManager.sheetSafeAreaInsets = safeAreaInsets
     }
 
     // MARK: CALayer

--- a/SheetsTests/PresentationAnimation/SheetTransitioningDelegateTests.swift
+++ b/SheetsTests/PresentationAnimation/SheetTransitioningDelegateTests.swift
@@ -48,4 +48,14 @@ class SheetTransitioningDelegateTests: XCTestCase {
 
         XCTAssertNil(subject.animationController(forDismissed: UIViewController()))
     }
+
+    func testPresentationController() {
+        let presentationController = subject.presentationController(
+            forPresented: UIViewController(),
+            presenting: UIViewController(),
+            source: UIViewController()
+        )
+
+        XCTAssertTrue(presentationController is SheetPresentationController)
+    }
 }

--- a/SheetsTests/SheetLayoutManagerTests.swift
+++ b/SheetsTests/SheetLayoutManagerTests.swift
@@ -15,13 +15,14 @@ class SheetLayoutManagerTests: XCTestCase {
         sheetView = SheetView(view: view, configuration: SheetConfiguration(supportedPositions: [.open, .half, .closed]))
 
         subject = sheetView.layoutManager
+        subject.sheetBounds = CGRect(x: 0, y: 0, width: 600, height: 600)
     }
 
     /// `init()` sets up the constraints and moves the sheet to the initial position.
     func testInit() {
         XCTAssertEqual(subject.position, .open)
         XCTAssertTrue(subject.openedConstraints.allSatisfy { $0.isActive })
-        XCTAssertEqual(subject.contentHeightConstraint.constant, UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.contentHeightConstraint.constant, 556)   // 556 = sheet height (600) - sheet configuration top inset (44)
     }
 
     /// `topPosition` returns the top position.
@@ -44,13 +45,13 @@ class SheetLayoutManagerTests: XCTestCase {
 
     /// `adjustContentHeight(with:)` adjusts the height of the content based on the pan translation.
     func testAdjustContentHeight() {
-        XCTAssertEqual(subject.contentHeightConstraint.constant, UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.contentHeightConstraint.constant, 556)   // 556 = sheet height (600) - sheet configuration top inset (44)
 
         subject.adjustContentHeight(with: 100)
-        XCTAssertEqual(subject.contentHeightConstraint.constant, UIScreen.main.bounds.height - 100)
+        XCTAssertEqual(subject.contentHeightConstraint.constant, 556 - 100)
 
         subject.adjustContentHeight(with: -500)
-        XCTAssertEqual(subject.contentHeightConstraint.constant, UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.contentHeightConstraint.constant, 556)
     }
 
     /// `move(to:)` can move the sheet to the half position.
@@ -59,7 +60,7 @@ class SheetLayoutManagerTests: XCTestCase {
 
         XCTAssertEqual(subject.position, .half)
         XCTAssertTrue(subject.halfConstraints.allSatisfy { $0.isActive })
-        XCTAssertEqual(subject.contentHeightConstraint.constant, UIScreen.main.bounds.height / 2)
+        XCTAssertEqual(subject.contentHeightConstraint.constant, 556 / 2)   // 556 = sheet height (600) - sheet configuration top inset (44)
     }
 
     /// `move(to:)` can move the sheet to the fittingSize position.
@@ -134,7 +135,7 @@ class SheetLayoutManagerTests: XCTestCase {
 
     /// `distance(from:to:)` returns the distance between a height and a position.
     func testDistance() {
-        XCTAssertEqual(subject.distance(from: 100, to: .open), 100 - UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.distance(from: 100, to: .open), 100 - 556)
         XCTAssertEqual(subject.distance(from: 100, to: .closed), 100)
     }
 
@@ -152,7 +153,7 @@ class SheetLayoutManagerTests: XCTestCase {
         XCTAssertEqual(subject.targetPosition(with: CGPoint(x: 0, y: 100), velocity: CGPoint(x: 0, y: -200)), .open)
 
         subject.move(to: .open)
-        subject.adjustContentHeight(with: UIScreen.main.bounds.height)
+        subject.adjustContentHeight(with: 556)  // 556 = sheet height (600) - sheet configuration top inset (44)
         XCTAssertEqual(subject.targetPosition(with: CGPoint(x: 0, y: 100), velocity: CGPoint(x: 0, y: 200)), .closed)
     }
 }

--- a/SheetsTests/SheetViewTests.swift
+++ b/SheetsTests/SheetViewTests.swift
@@ -19,6 +19,9 @@ class SheetViewTests: XCTestCase {
 
         subject = SheetView(view: view, configuration: configuration)
         subject.backgroundAnimator = backgroundAnimator
+
+        subject.frame = CGRect(x: 0, y: 0, width: 600, height: 600)
+        subject.layoutIfNeeded()
     }
 
     /// `init(view:configuration)` sets up the view.
@@ -35,22 +38,23 @@ class SheetViewTests: XCTestCase {
         subject.layoutIfNeeded()
 
         XCTAssertFalse(subject.point(inside: CGPoint(x: -5, y: -5), with: nil))
-        XCTAssertTrue(subject.point(inside: CGPoint(x: 5, y: 5), with: nil))
+        XCTAssertTrue(subject.point(inside: CGPoint(x: 0, y: 44), with: nil))
         XCTAssertTrue(subject.point(inside: CGPoint(x: 100, y: 100), with: nil))
     }
 
     /// `safeAreaInsetsDidChange()` notifies the layout manager of the safe area insets.
     func testSafeAreaInsetsDidChange() {
-        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 556)
 
         // NOTE: `safeAreaInsets` can't be set directly, but we can use the fact that the layout
         // manager updates the constraints based on the bounds and safe area of the `SheetView`, so
         // updating the view's frame and calling `safeAreaInsetsDidChange` should update the
         // constraints as well.
-        subject.frame = CGRect(x: 0, y: 0, width: 600, height: 600)
+        subject.frame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+        subject.layoutIfNeeded()
         subject.safeAreaInsetsDidChange()
 
-        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 556)
+        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 956)
     }
 
     /// `hitTest(_:with)` returns the view that contains the specified point.
@@ -108,26 +112,26 @@ class SheetViewTests: XCTestCase {
     func testPanningChanged() {
         let translation = CGPoint(x: 0, y: 100)
 
-        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 556)
 
         subject.startSheetInteraction(translation: CGPoint.zero)
         subject.panningChanged(translation: translation)
 
-        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, UIScreen.main.bounds.height - 100)
+        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 556 - 100)
     }
 
     /// `panningEnded(translation:velocity:)` moves the sheet to the targeted position based on the translation, velocity and supported positions.
     func testPanningEnded() {
         let translation = CGPoint(x: 0, y: 400)
 
-        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, UIScreen.main.bounds.height)
+        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 556)
         XCTAssertEqual(backgroundAnimator.fractionComplete, 0)
 
         subject.startSheetInteraction(translation: CGPoint.zero)
         subject.panningChanged(translation: translation)
         subject.panningEnded(translation: translation, velocity: CGPoint(x: 0, y: 100))
 
-        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, UIScreen.main.bounds.height / 2)
+        XCTAssertEqual(subject.layoutManager.contentHeightConstraint.constant, 556 / 2)
     }
 
     /// `shouldScrollViewHandleGesture(location:)` determines if a pan gesture should be handled by the scroll view or the sheet.
@@ -164,7 +168,7 @@ class SheetViewTests: XCTestCase {
         XCTAssertTrue(subject.shouldStopSheetInteraction(translation: CGPoint(x: 0, y: -5)))
     }
 
-    /// The scroll view's pan gesture recognizer should be recognized simulatneously with the sheet view's pan gesture recognizer.
+    /// The scroll view's pan gesture recognizer should be recognized simultaneously with the sheet view's pan gesture recognizer.
     func testGestureRecognizerShouldRecognizeSimultaneouslyWith() {
         let scrollView = UIScrollView()
         subject.scrollView = scrollView


### PR DESCRIPTION
This fixes several issues related to the in-call status bar.

- [x] In-call status bar is present; present a full sheet, the top of the sheet goes beneath the status bar.
- [x] When the in-call status bar is present, the bottom of the sheet extends 20pt past the bottom of the screen.
- [x] Hiding the in-call status bar while a sheet is open leaves the dimmed background view pushed down below the status bar instead of all of the way at the top of the screen.
- [x] The distance between the top of a full sheet and the bottom of the status bar doesn't remain constant when the in-call status bar appears.

![sheets-status-bar](https://user-images.githubusercontent.com/11882/86016796-de383c00-b9e8-11ea-83f3-312c973cfed4.gif)
