### PR TITLE
Adds an optional configuration property for a background color that appears behind the keyboard

### DIFF
--- a/Duvet/Configuration/SheetConfiguration.swift
+++ b/Duvet/Configuration/SheetConfiguration.swift
@@ -19,6 +19,10 @@ public struct SheetConfiguration: Equatable {
     /// The sheets initial position.
     public var initialPosition: SheetPosition
 
+    /// The color of the optional keyboard shim. If no value is provided the keyboard shim is not
+    /// displayed.
+    public var keyboardBackgroundColor: UIColor?
+
     /// The list of positions that the view is allowed to adjusted to via panning the view.
     public var supportedPositions: [SheetPosition]
 
@@ -35,6 +39,9 @@ public struct SheetConfiguration: Equatable {
     ///     scroll view is scrolled or false otherwise.
     ///   - handleConfiguration: Configuration parameters for displaying a sheet handle.
     ///   - initialPosition: The sheets initial position.
+    ///   - keyboardBackgroundColor: An optional color for a shim view that appears behind the
+    ///     keyboard when it is presented. This prevents interactive dismissing of the keyboard
+    ///     showing the background view while the keyboard is being dragged down.
     ///   - supportedPositions: The list of positions that the view is allowed to be adjusted to via
     ///     panning the view.
     ///   - topInset: The number of points that the sheet should sit below the top safe area.
@@ -46,6 +53,7 @@ public struct SheetConfiguration: Equatable {
         dismissKeyboardOnScroll: Bool = true,
         handleConfiguration: SheetHandleConfiguration? = nil,
         initialPosition: SheetPosition = .open,
+        keyboardBackgroundColor: UIColor? = nil,
         supportedPositions: [SheetPosition] = [.open],
         topInset: CGFloat = 44
     ) {
@@ -53,6 +61,7 @@ public struct SheetConfiguration: Equatable {
         self.dismissKeyboardOnScroll = dismissKeyboardOnScroll
         self.handleConfiguration = handleConfiguration
         self.initialPosition = initialPosition
+        self.keyboardBackgroundColor = keyboardBackgroundColor
         self.supportedPositions = supportedPositions
         self.topInset = topInset
     }

--- a/Duvet/SheetLayoutManager.swift
+++ b/Duvet/SheetLayoutManager.swift
@@ -56,6 +56,9 @@ struct SheetLayoutManager {
     /// Content view constraints that are fixed regardless of the sheet's position.
     var fixedConstraints = [NSLayoutConstraint]()
 
+    /// The view to display below the keyboard.
+    lazy var keyboardBackgroundView = UIView()
+
     /// Content view constraints that move the sheet into the opened position when active.
     var openedConstraints = [NSLayoutConstraint]()
 
@@ -111,6 +114,10 @@ struct SheetLayoutManager {
         contentHeightConstraint = contentView.heightAnchor.constraint(equalToConstant: 0)
         fittingSizeHeightConstraint = contentView.heightAnchor.constraint(equalTo: contentView.heightAnchor)
         fittingSizeMaxHeightConstraint = contentView.heightAnchor.constraint(lessThanOrEqualToConstant: 0)
+
+        if let color = configuration.keyboardBackgroundColor {
+            keyboardBackgroundView.backgroundColor = color
+        }
 
         setUpConstraints(sheetView: sheetView, contentView: contentView)
     }
@@ -341,6 +348,17 @@ struct SheetLayoutManager {
             fittingSizeMaxHeightConstraint,
         ]
         fittingSizeHeightConstraint.priority = .init(999)
+
+        if configuration.keyboardBackgroundColor != nil {
+            keyboardBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+            sheetView.addSubview(keyboardBackgroundView)
+            NSLayoutConstraint.activate([
+                keyboardBackgroundView.topAnchor.constraint(equalTo: contentView.bottomAnchor),
+                keyboardBackgroundView.leadingAnchor.constraint(equalTo: sheetView.leadingAnchor),
+                keyboardBackgroundView.trailingAnchor.constraint(equalTo: sheetView.trailingAnchor),
+                keyboardBackgroundView.bottomAnchor.constraint(equalTo: sheetView.bottomAnchor),
+            ])
+        }
 
         let handleInset = configuration.handleConfiguration?.topInset ?? 0
         closedConstraints = [

--- a/DuvetTests/Configuration/SheetConfigurationTests.swift
+++ b/DuvetTests/Configuration/SheetConfigurationTests.swift
@@ -16,6 +16,7 @@ class SheetConfigurationTests: XCTestCase {
         XCTAssertEqual(subject.cornerRadius, 10)
         XCTAssertNil(subject.handleConfiguration)
         XCTAssertEqual(subject.initialPosition, .open)
+        XCTAssertNil(subject.keyboardBackgroundColor)
         XCTAssertEqual(subject.supportedPositions, [.open])
         XCTAssertEqual(subject.topInset, 44)
     }

--- a/DuvetTests/SheetLayoutManagerTests.swift
+++ b/DuvetTests/SheetLayoutManagerTests.swift
@@ -156,4 +156,35 @@ class SheetLayoutManagerTests: XCTestCase {
         subject.adjustContentHeight(with: 556)  // 556 = sheet height (600) - sheet configuration top inset (44)
         XCTAssertEqual(subject.targetPosition(with: CGPoint(x: 0, y: 100), velocity: CGPoint(x: 0, y: 200)), .closed)
     }
+
+    /// When using the default keyboard background view value, make sure the `keyboardBackgroundView`
+    /// is not added to the view hierarchy and it doesn't have a background color.
+    func testDefaultKeyboardBackgroundViewSetup() {
+        XCTAssertFalse(sheetView.subviews.contains(subject.keyboardBackgroundView))
+        XCTAssertNil(subject.keyboardBackgroundView.backgroundColor)
+    }
+
+    /// When using a custom keyboard background color, make sure the `keyboardBackgroundView` is
+    /// added to the view hierarchy and it has the correct background color.
+    func testCustomKeyboardBackgroundViewSetup() {
+        sheetView = SheetView(view: view, configuration: SheetConfiguration(keyboardBackgroundColor: .blue))
+        subject = sheetView.layoutManager
+
+        XCTAssertTrue(sheetView.subviews.contains(subject.keyboardBackgroundView))
+        XCTAssertEqual(subject.keyboardBackgroundView.backgroundColor, .blue)
+    }
+
+    /// `updateSheetForKeyboardHeight(_:)` slides the sheet up when in the fittingSize position and
+    /// the keyboard background view is resized accordingly.
+    func testUpdateSheetForKeyboardHeightFittingSizeWithKeyboardBackgroundColor() {
+        sheetView = SheetView(view: view, configuration: SheetConfiguration(initialPosition: .fittingSize, keyboardBackgroundColor: .blue, supportedPositions: [.fittingSize]))
+        subject = sheetView.layoutManager
+        subject.sheetBounds = CGRect(x: 0, y: 0, width: 600, height: 600)
+
+        subject.move(to: .fittingSize)
+        subject.updateSheetForKeyboardHeight(100)
+        sheetView.layoutIfNeeded()
+
+        XCTAssertEqual(subject.keyboardBackgroundView.frame.height, 100)
+    }
 }

--- a/Examples/DuvetExample/DuvetExample.xcodeproj/project.pbxproj
+++ b/Examples/DuvetExample/DuvetExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		66A269B12605089D00A25D60 /* KeyboardInteractiveDismissViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A269B02605089D00A25D60 /* KeyboardInteractiveDismissViewController.swift */; };
 		C9336969219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9336968219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift */; };
 		C9496F9A219B2D0C003753AC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9496F99219B2D0C003753AC /* AppDelegate.swift */; };
 		C9496F9C219B2D0C003753AC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9496F9B219B2D0C003753AC /* ViewController.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		66A269B02605089D00A25D60 /* KeyboardInteractiveDismissViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInteractiveDismissViewController.swift; sourceTree = "<group>"; };
 		C9336968219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredBackgroundViewController.swift; sourceTree = "<group>"; };
 		C9496F96219B2D0C003753AC /* DuvetExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DuvetExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9496F99219B2D0C003753AC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				C9A3BE6D219CC4A900ED599B /* FullSizeViewController.swift */,
 				C982073321B1972E0032CED9 /* KeyboardFullViewController.swift */,
 				C99A872F21AF363200F8E7D2 /* KeyboardViewController.swift */,
+				66A269B02605089D00A25D60 /* KeyboardInteractiveDismissViewController.swift */,
 				C99A872621ADB09100F8E7D2 /* PushPopViewController.swift */,
 				C9A3BE6F219CC63400ED599B /* ScrollViewHeaderFooterViewController.swift */,
 			);
@@ -248,6 +251,7 @@
 				C9A3BE64219CC42400ED599B /* BaseViewController.swift in Sources */,
 				C9496FB6219B2DCD003753AC /* AppCoordinator.swift in Sources */,
 				C9A3BE6E219CC4A900ED599B /* FullSizeViewController.swift in Sources */,
+				66A269B12605089D00A25D60 /* KeyboardInteractiveDismissViewController.swift in Sources */,
 				C9336969219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift in Sources */,
 				C9A3BE61219CC2F700ED599B /* SheetHeaderView.swift in Sources */,
 				C982073421B1972E0032CED9 /* KeyboardFullViewController.swift in Sources */,

--- a/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController {
         case fullSize = "Full Size"
         case keyboard = "Keyboard - Fitting Size"               // Sheet handles adjusting contained view with keyboard.
         case keyboardFull = "Keyboard - Expand with Keyboard"   // Contained view responsible for keyboard adjustments.
+        case keyboardInteractiveDismiss = "Keyboard - Interactive Dismiss"
         case pushPop = "Push/Pop"
         case scrollViewHeaderFooter = "Scroll View with Header and Footer"
 
@@ -52,6 +53,8 @@ class ViewController: UIViewController {
                 return KeyboardViewController.self
             case .keyboardFull:
                 return KeyboardFullViewController.self
+            case .keyboardInteractiveDismiss:
+                return KeyboardInteractiveDismissViewController.self
             case .pushPop:
                 return PushPopViewController.self
             case .scrollViewHeaderFooter:

--- a/Examples/DuvetExample/DuvetExample/Application/ViewControllers/KeyboardInteractiveDismissViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewControllers/KeyboardInteractiveDismissViewController.swift
@@ -1,0 +1,128 @@
+import Duvet
+import UIKit
+
+// MARK: - KeyboardInteractiveDismissViewController
+
+/// A sheet view that displays a text view for user input. The sheet view is sized to fit the
+/// content. When the text view becomes the first responder, the bottom of the sheet is adjusted to
+/// account for the size of the keyboard. This example utilizes the optional configuration property
+/// `keyboardBackgroundColor` to display a background view behind the keyboard that has the color
+/// provided.
+class KeyboardInteractiveDismissViewController: BaseViewController, ProvidesSheetConfiguration {
+    static var sheetConfiguration: SheetConfiguration = SheetConfiguration(
+        initialPosition: .fittingSize,
+        keyboardBackgroundColor: .white,
+        supportedPositions: [.fittingSize])
+
+    // MARK: Properties
+
+    /// The done button at the bottom of the view.
+    lazy var doneButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        button.backgroundColor = .black
+        button.heightAnchor.constraint(equalToConstant: 56).isActive = true
+        button.layer.cornerRadius = 4
+        button.setTitle("Done", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        return button
+    }()
+
+    /// The header displayed above the text view.
+    lazy var header: SheetHeaderView = {
+        let header = SheetHeaderView()
+        header.translatesAutoresizingMaskIntoConstraints = false
+        header.closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        return header
+    }()
+
+    /// A view used to wrap the content of the scroll view.
+    lazy private var scrollContentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .white
+        view.addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.topAnchor, constant: 16),
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -16),
+        ])
+        return view
+    }()
+
+    /// The scroll view used to make the textfield scrollable.
+    lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.keyboardDismissMode = .interactive
+        scrollView.addSubview(scrollContentView)
+        NSLayoutConstraint.activate([
+            scrollContentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+
+            scrollContentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            scrollContentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            scrollContentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            scrollContentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+        ])
+        return scrollView
+    }()
+
+    /// The text view used to accept user input.
+    lazy var textView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height).isActive = true
+        textView.backgroundColor = UIColor(red: 242/255, green: 242/255, blue: 247/255, alpha: 1)
+        textView.layer.cornerRadius = 10
+        textView.isScrollEnabled = false
+        textView.font = .systemFont(ofSize: 17)
+        textView.text = "This is some initial scrollable text. Tap to edit to see how the keyboard interacts with this view."
+        return textView
+    }()
+
+    /// A constraint used to ensure that the scroll view takes up all the available vertical space.
+    lazy var scrollViewHeightConstraint: NSLayoutConstraint = {
+        // allows the scroll view to take up the maximum amount of vertical space without going off screen
+        let constraint = scrollView.heightAnchor.constraint(equalTo: scrollContentView.heightAnchor)
+        constraint.priority = .init(999)
+        return constraint
+    }()
+
+    // MARK: UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        header.titleLabel.text = title
+
+        view.addSubview(scrollView)
+        view.addSubview(header)
+        view.addSubview(doneButton)
+
+        NSLayoutConstraint.activate([
+            header.topAnchor.constraint(equalTo: view.topAnchor),
+            header.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            scrollView.topAnchor.constraint(equalTo: header.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollViewHeightConstraint,
+
+            doneButton.topAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 16),
+            doneButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            doneButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            doneButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+        ])
+    }
+
+    // MARK: Private Methods
+
+    /// A hander for the close button being tapped.
+    @objc private func closeButtonTapped() {
+        view.endEditing(true)
+        coordinator?.dismissSheet()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Various parameters can be configured for a sheet via a `SheetConfiguration` when
 | `dismissKeyboardOnScroll` | True if the keyboard should be dismissed when the sheet view's scroll view is scrolled. Defaults to `true`. |
 | `handleConfiguration` | An optional configuration for displaying a handle in or above the sheet to indicate that the sheet can be panned. Defaults to `nil` for no handle. |
 | `initialPosition` | The initial position of the sheet when presented. Defaults to `.open` for a full sized sheet. |
+| `keyboardBackgroundColor` | An optional color for a view that is presented behind the keyboard when this sheet view is adjusted for keyboard presentation. If no color is provided no view will appear behind the keyboard. Defaults to `nil`. |
 | `supportedPositions` | The list of positions that the sheet can be adjusted to via sliding. Defaults to `[.open]`, which only allows the sheet to be fully sized or closed. |
 | `topInset` | The number of points between the top of the sheet and the top safe area. Defaults to 44. |
 


### PR DESCRIPTION
This PR adds a configuration property to `SheetConfiguration` that allows a developer to setup a background color that appears behind the keyboard when the sheet is presented in the `.fittingSize` style and the keyboard is present. This prevents the view behind the `SheetView` from peeking through when dismissing the keyboard. See the screenshots below to see an example of both using and not using this new property and dismissing the keyboard.

The new example titled "Keyboard - Interactive Dismiss" uses this new feature.

<img src="https://user-images.githubusercontent.com/6438337/111837583-1c062900-88c6-11eb-80a8-30aeb0db4e0a.png" alt="Dismissing the keyboard interactively WITHOUT a background color" width="300">                  <img src="https://user-images.githubusercontent.com/6438337/111837580-1ad4fc00-88c6-11eb-9e96-210e3ba46f2e.png" alt="Dismissing the keyboard interactively WITH a background color" width="300">
