### PR TITLE
Fix Pushing a SheetItem After Initializing a SheetViewController w/ a Nil SheetItem

### DIFF
--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -7,9 +7,6 @@ public class SheetViewController: UIViewController {
 
     // MARK: Properties
 
-    /// The currently presented sheet item.
-    private var currentSheetItem: SheetItem?
-
     /// The delegate of the view controller.
     public weak var delegate: SheetViewControllerDelegate?
 
@@ -97,7 +94,7 @@ public class SheetViewController: UIViewController {
                                        name: UIResponder.keyboardWillChangeFrameNotification,
                                        object: nil)
 
-        if let sheetItem = sheetItems.last, currentSheetItem == nil {
+        if let sheetItem = sheetItems.last, sheetItem.viewController.parent != self {
             transitionSheet(fromSheetItem: nil, toSheetItem: sheetItem, forward: true, animated: false)
         }
     }
@@ -230,8 +227,6 @@ public class SheetViewController: UIViewController {
     ///   - animated: True if the transition should be animated.
     ///
     private func transitionSheet(fromSheetItem: SheetItem?, toSheetItem: SheetItem?, forward: Bool, animated: Bool) {
-        self.currentSheetItem = toSheetItem
-
         guard let toSheetItem = toSheetItem else {
             delegate?.dismissSheetViewController()
             return

--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -7,6 +7,9 @@ public class SheetViewController: UIViewController {
 
     // MARK: Properties
 
+    /// The currently presented sheet item.
+    private var currentSheetItem: SheetItem?
+
     /// The delegate of the view controller.
     public weak var delegate: SheetViewControllerDelegate?
 
@@ -94,7 +97,7 @@ public class SheetViewController: UIViewController {
                                        name: UIResponder.keyboardWillChangeFrameNotification,
                                        object: nil)
 
-        if let sheetItem = sheetItems.last {
+        if let sheetItem = sheetItems.last, currentSheetItem == nil {
             transitionSheet(fromSheetItem: nil, toSheetItem: sheetItem, forward: true, animated: false)
         }
     }
@@ -227,6 +230,8 @@ public class SheetViewController: UIViewController {
     ///   - animated: True if the transition should be animated.
     ///
     private func transitionSheet(fromSheetItem: SheetItem?, toSheetItem: SheetItem?, forward: Bool, animated: Bool) {
+        self.currentSheetItem = toSheetItem
+
         guard let toSheetItem = toSheetItem else {
             delegate?.dismissSheetViewController()
             return

--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -94,6 +94,8 @@ public class SheetViewController: UIViewController {
                                        name: UIResponder.keyboardWillChangeFrameNotification,
                                        object: nil)
 
+        // Setup the first sheet if it hasn't already been added as a child. Since the view is loaded
+        // while adding the first sheet's subview, `sheetView` will still be nil so instead check the parent.
         if let sheetItem = sheetItems.last, sheetItem.viewController.parent != self {
             transitionSheet(fromSheetItem: nil, toSheetItem: sheetItem, forward: true, animated: false)
         }

--- a/Duvet/SheetViewControllerDelegate.swift
+++ b/Duvet/SheetViewControllerDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Delegate protocol for `SheetViewController`.
 ///
-public protocol SheetViewControllerDelegate: class {
+public protocol SheetViewControllerDelegate: AnyObject {
 
     /// The sheet view controller should be dismissed due to a tap in the background view.
     ///

--- a/Duvet/SheetViewDelegate.swift
+++ b/Duvet/SheetViewDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Delegate protocol for `SheetView`.
 ///
-protocol SheetViewDelegate: class {
+protocol SheetViewDelegate: AnyObject {
 
     /// The sheet has been moved offscreen and should be dismissed.
     ///

--- a/DuvetTests/SheetViewControllerTests.swift
+++ b/DuvetTests/SheetViewControllerTests.swift
@@ -48,6 +48,15 @@ class SheetViewControllerTests: XCTestCase {
         XCTAssertTrue(sheetView.contentView.contains(sheetItem.viewController.view))
     }
 
+    /// `viewDidLoad()` doesn't add the first sheet if it has already been pushed.
+    func testViewDidLoadDoesntAddFirstSheetIfAlreadyPushed() {
+        subject.push(sheetItem: sheetItem, animated: false)
+        XCTAssertEqual(subject.view.subviews.count, 2)
+
+        subject.viewDidLoad()
+        XCTAssertEqual(subject.view.subviews.count, 2)
+    }
+
     /// When the background view is tapped, it requests that the delegate dismiss the view.
     func testBackgroundTapped() {
         subject.viewDidLoad()


### PR DESCRIPTION
This PR fixes an issue when pushing a `SheetItem` after initializing a `SheetViewController` with a nil sheet item. In this case, both `viewDidLoad()` and `push(sheetItem:animated:)` were attempting to add the new sheet item to the view controller, causing the view to be animated incorrectly and some extra non-interactive views to be left on top of the expected content.

### To Recreate
```
// Create an empty SheetViewController
let sheetViewController = SheetViewController()

// Immediately push a `SheetItem`
sheetViewController.push(sheetItem: SheetItem(), animated: false)

// Present the SheetViewController
navigationController.present(sheetViewController, animated: true)
```

Notice that `viewDidLoad` gets called after the call to push the new sheet item, causing the view controller to try to add the same sheet item twice.


https://user-images.githubusercontent.com/48719972/136092692-79549e3f-474f-4503-8894-e64e1da4c244.mp4

<img width="1487" alt="Screen Shot 2021-10-05 at 3 49 31 PM" src="https://user-images.githubusercontent.com/48719972/136092816-2b177ce6-d6dc-4404-80ca-28a211d1fbb7.png">

