### PR TITLE
Don't Adjust Sheet for Keyboard When Presenting Another View Controller

### DIFF
--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -193,7 +193,8 @@ public class SheetViewController: UIViewController {
     @objc private func adjustViewForKeyboard(notification: Notification) {
         guard let userInfo = notification.userInfo,
             let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval,
-            let keyboardFrameEnd = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            let keyboardFrameEnd = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
+            presentedViewController == nil // don't adjust for the keyboard while presenting another view controller
             else {
                 return
         }

--- a/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
@@ -14,8 +14,8 @@ class ViewController: UIViewController {
     // MARK: Types
 
     enum Sheets: String, CaseIterable {
-        case adjustable = "Adustable"
-        case adjustableWithScroll = "Adustable with Scroll View"
+        case adjustable = "Adjustable"
+        case adjustableWithScroll = "Adjustable with Scroll View"
         case blurredBackground = "Blurred Background"
         case half = "Half Size"
         case fittingSize = "Fitting Size"


### PR DESCRIPTION
This PR fixes an issue when presenting a view on top of a sheet that displays a keyboard. Previously the sheet would continue responding to keyboard notifications underneath the presented view controller. This adds a check to keep the sheet in place when the keyboard is presented for a view on top of the sheet so that it doesn't jump around when the presented view controller is dismissed.