### PR TITLE
Fix Auto Layout Warnings For Showing Fitting Size Sheets with Fixed Size Constraints

### DIFF
--- a/Duvet/SheetLayoutManager.swift
+++ b/Duvet/SheetLayoutManager.swift
@@ -32,6 +32,7 @@ struct SheetLayoutManager {
 
     /// Constant that defines the height of the content view when in the `opened` position.
     var contentHeightConstant: CGFloat {
+        guard !sheetBounds.isEmpty else { return UIScreen.main.bounds.height }
         return max(0, sheetBounds.height - (sheetSafeAreaInsets.top + configuration.topInset))
     }
 

--- a/DuvetTests/SheetLayoutManagerTests.swift
+++ b/DuvetTests/SheetLayoutManagerTests.swift
@@ -22,7 +22,14 @@ class SheetLayoutManagerTests: XCTestCase {
     func testInit() {
         XCTAssertEqual(subject.position, .open)
         XCTAssertTrue(subject.openedConstraints.allSatisfy { $0.isActive })
+    }
+
+    /// `contentHeightConstant` returns the expected height constant.
+    func testContentHeightConstant() {
         XCTAssertEqual(subject.contentHeightConstraint.constant, 556)   // 556 = sheet height (600) - sheet configuration top inset (44)
+
+        subject.sheetBounds = .zero
+        XCTAssertEqual(subject.contentHeightConstant, UIScreen.main.bounds.height)
     }
 
     /// `topPosition` returns the top position.


### PR DESCRIPTION
This PR prevents auto layout warnings when first presenting a fitting size sheet with a fixed height constraint on any of its views. This was caused by the sheet view having empty bounds when the fitting size max height constraint is first added, causing that constraint to conflict with any height constraints on the sheet's view. To fix, we just use the screen's height if the sheet doesn't yet have a size.

For ex, I added this to the example project to reproduce, with the key being the final constraint that's added:

```
import Duvet
import UIKit

class FixedConstraintViewController: BaseViewController, ProvidesSheetConfiguration {

    static let sheetConfiguration = SheetConfiguration(
        initialPosition: .fittingSize,
        supportedPositions: [.fittingSize]
    )

    // MARK: Properties

    let fixedHeightView: UIView = {
        let view = UIView()
        view.backgroundColor = .systemBlue
        view.translatesAutoresizingMaskIntoConstraints = false
        return view
    }()

    override func viewDidLoad() {
        super.viewDidLoad()

        view.addSubview(fixedHeightView)

        NSLayoutConstraint.activate([
            fixedHeightView.topAnchor.constraint(equalTo: view.topAnchor),
            fixedHeightView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
            fixedHeightView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
            fixedHeightView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
            fixedHeightView.heightAnchor.constraint(equalToConstant: 200), // fix the height
        ])
    }
}
```