### PR TITLE
Adds an option for using the default keyboard avoidance

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Duvet.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Duvet.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Duvet"
+               BuildableName = "Duvet"
+               BlueprintName = "Duvet"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DuvetTests"
+               BuildableName = "DuvetTests"
+               BlueprintName = "DuvetTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Duvet"
+            BuildableName = "Duvet"
+            BlueprintName = "Duvet"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Duvet/Configuration/SheetConfiguration.swift
+++ b/Duvet/Configuration/SheetConfiguration.swift
@@ -25,6 +25,11 @@ public struct SheetConfiguration: Equatable {
     /// The number of points that the sheet should sit below the top safe area.
     public var topInset: CGFloat
 
+    /// A flag indicating if this sheet should use Duvet's default keyboard avoidance or not. If `true`,
+    /// Duvet will handle keyboard avoidance, otherwise it will do nothing when the keyboard is presented
+    /// or dismissed.
+    public var usesDefaultKeyboardAvoidance: Bool
+
     // MARK: Initialization
 
     /// Initialize a `SheetConfiguration`.
@@ -38,6 +43,8 @@ public struct SheetConfiguration: Equatable {
     ///   - supportedPositions: The list of positions that the view is allowed to be adjusted to via
     ///     panning the view.
     ///   - topInset: The number of points that the sheet should sit below the top safe area.
+    ///   - usesDefaultKeyboardAvoidance: A flag indicating if this sheet should use Duvet's default keyboard
+    ///      avoidance or not.
     ///
     public init(
         // NOTE: If a default value is changed here, be sure to update the Configuration section
@@ -47,7 +54,8 @@ public struct SheetConfiguration: Equatable {
         handleConfiguration: SheetHandleConfiguration? = nil,
         initialPosition: SheetPosition = .open,
         supportedPositions: [SheetPosition] = [.open],
-        topInset: CGFloat = 44
+        topInset: CGFloat = 44,
+        usesDefaultKeyboardAvoidance: Bool = true
     ) {
         self.cornerRadius = cornerRadius
         self.dismissKeyboardOnScroll = dismissKeyboardOnScroll
@@ -55,5 +63,6 @@ public struct SheetConfiguration: Equatable {
         self.initialPosition = initialPosition
         self.supportedPositions = supportedPositions
         self.topInset = topInset
+        self.usesDefaultKeyboardAvoidance = usesDefaultKeyboardAvoidance
     }
 }

--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -193,7 +193,8 @@ public class SheetViewController: UIViewController {
     /// - Parameter notification: The keyboard notification.
     ///
     @objc private func adjustViewForKeyboard(notification: Notification) {
-        guard let userInfo = notification.userInfo,
+        guard sheetView?.configuration.usesDefaultKeyboardAvoidance ?? false,
+            let userInfo = notification.userInfo,
             let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval,
             let keyboardFrameEnd = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
             presentedViewController == nil // don't adjust for the keyboard while presenting another view controller

--- a/DuvetTests/Configuration/SheetConfigurationTests.swift
+++ b/DuvetTests/Configuration/SheetConfigurationTests.swift
@@ -18,5 +18,6 @@ class SheetConfigurationTests: XCTestCase {
         XCTAssertEqual(subject.initialPosition, .open)
         XCTAssertEqual(subject.supportedPositions, [.open])
         XCTAssertEqual(subject.topInset, 44)
+        XCTAssertTrue(subject.usesDefaultKeyboardAvoidance)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -10,5 +10,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "Duvet", dependencies: [], path: "Duvet"),
+        .testTarget(name: "DuvetTests", dependencies: ["Duvet"], path: "DuvetTests"),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A configurable framework for presenting bottom sheets on iOS.
 
 | Full Sheet | Half Sheet | Fitting Size Sheet | Fitting Size with a Keyboard |
 | --- | --- | --- | --- |
-| ![Full Sheet](Docs/Images/full_sheet.png) | ![Half Sheet](Docs/Images/half_sheet.png) | ![Fitting Size Sheet](Docs/Images/fitting_size_sheet.png) | ![Fitting Size with Keyboard](Docs/Images/fitting_size_sheet_with_keyboard.png) | 
+| ![Full Sheet](Docs/Images/full_sheet.png) | ![Half Sheet](Docs/Images/half_sheet.png) | ![Fitting Size Sheet](Docs/Images/fitting_size_sheet.png) | ![Fitting Size with Keyboard](Docs/Images/fitting_size_sheet_with_keyboard.png) |
 
 ## Requirements
 
@@ -61,7 +61,7 @@ Add `github livefront/Duvet` to your `Cartfile`.
 1. Import `Duvet` into the file that you will present a sheet from.
 
     ```swift
-    import Duvet 
+    import Duvet
     ```
 
 1. Create a `SheetItem` with the view controller that should will be shown in the sheet.
@@ -115,6 +115,7 @@ Various parameters can be configured for a sheet via a `SheetConfiguration` when
 | `initialPosition` | The initial position of the sheet when presented. Defaults to `.open` for a full sized sheet. |
 | `supportedPositions` | The list of positions that the sheet can be adjusted to via sliding. Defaults to `[.open]`, which only allows the sheet to be fully sized or closed. |
 | `topInset` | The number of points between the top of the sheet and the top safe area. Defaults to 44. |
+| `usesDefaultKeyboardAvoidance` | A flag that determines if Duvet should use its own custom keyboard avoidance mechanism for this sheet or not. This is defaulted to `true`, but if your app handles keyboard avoidance in it's own way, it is recommended that this flag is set to `false` to reduce animation conflicts. |
 
 ### Scroll View Interaction
 
@@ -126,7 +127,7 @@ For this interaction to occur, pass a reference to your view controller's scroll
 let sheetItem = SheetItem(
     viewController: viewController,
     configuration: SheetConfiguration(),
-    scrollView: viewController.scrollView 
+    scrollView: viewController.scrollView
 )
 ```
 
@@ -144,7 +145,7 @@ let sheetItem = SheetItem(
 
     ```swift
     let sheetItem = SheetItem(
-        viewController: <view controller for the first sheet> 
+        viewController: <view controller for the first sheet>
         configuration: SheetConfiguration(),
         scrollView: nil
     )
@@ -159,7 +160,7 @@ let sheetItem = SheetItem(
 
     ```swift
     let sheetItem2 = SheetItem(
-        viewController: <view controller for the second sheet> 
+        viewController: <view controller for the second sheet>
         configuration: SheetConfiguration(),
         scrollView: nil
     )


### PR DESCRIPTION
This PR adds a new configuration option for Sheets that allows them to specify if Duvet should use its default keyboard avoidance or not. This fixes animation issues in apps that present a sheet with a single navigation controller in them that pushes its own view controllers onto the stack. The default value of this new configuration setting is `true` to ensure that the previous behavior is retained.

This PR also adds the existing test target to the Package definition for this project, to make running unit tests possible.