### PR TITLE
Update background dimming to only undim when moving to the closed position

### DIFF
--- a/DuvetTests/SheetLayoutManagerTests.swift
+++ b/DuvetTests/SheetLayoutManagerTests.swift
@@ -18,6 +18,29 @@ class SheetLayoutManagerTests: XCTestCase {
         subject.sheetBounds = CGRect(x: 0, y: 0, width: 600, height: 600)
     }
 
+    /// `backgroundDimmingFractionComplete` returns a fraction value that indicates what percentage
+    /// the sheet is covering the area between the position above closed and closed positions.
+    func testBackgroundDimmingFractionComplete() {
+        XCTAssertEqual(subject.backgroundDimmingFractionComplete, 0)
+
+        subject.move(to: .half)
+        XCTAssertEqual(subject.backgroundDimmingFractionComplete, 0)
+
+        // Sheet height @ half = 278. Sheet height @ closed = 0.
+
+        subject.contentHeightConstraint.constant = 208.5
+        XCTAssertEqual(subject.backgroundDimmingFractionComplete, 0.25)
+
+        subject.contentHeightConstraint.constant = 69.5
+        XCTAssertEqual(subject.backgroundDimmingFractionComplete, 0.75)
+
+        subject.move(to: .closed)
+        XCTAssertEqual(subject.backgroundDimmingFractionComplete, 1)
+
+        sheetView = SheetView(view: view, configuration: SheetConfiguration(supportedPositions: [.open]))
+        XCTAssertNil(sheetView.layoutManager.backgroundDimmingFractionComplete)
+    }
+
     /// `init()` sets up the constraints and moves the sheet to the initial position.
     func testInit() {
         XCTAssertEqual(subject.position, .open)
@@ -30,24 +53,6 @@ class SheetLayoutManagerTests: XCTestCase {
 
         subject.sheetBounds = .zero
         XCTAssertEqual(subject.contentHeightConstant, UIScreen.main.bounds.height)
-    }
-
-    /// `topPosition` returns the top position.
-    func testTopPosition() {
-        XCTAssertEqual(subject.topPosition, .open)
-
-        sheetView = SheetView(view: UIView(), configuration: SheetConfiguration(supportedPositions: [.fittingSize]))
-        subject = sheetView.layoutManager
-        XCTAssertEqual(subject.topPosition, .fittingSize)
-    }
-
-    /// `secondPosition` returns the second from the top position.
-    func testSecondPosition() {
-        XCTAssertEqual(subject.secondPosition, .half)
-
-        sheetView = SheetView(view: UIView(), configuration: SheetConfiguration(supportedPositions: [.fittingSize]))
-        subject = sheetView.layoutManager
-        XCTAssertNil(subject.secondPosition)
     }
 
     /// `adjustContentHeight(with:)` adjusts the height of the content based on the pan translation.
@@ -86,6 +91,19 @@ class SheetLayoutManagerTests: XCTestCase {
         XCTAssertEqual(subject.position, .closed)
         XCTAssertTrue(subject.closedConstraints.allSatisfy { $0.isActive })
         XCTAssertEqual(subject.contentHeightConstraint.constant, 0)
+    }
+
+    /// `positionAboveClosed` returns the position immediately above the closed position.
+    func testPositionAboveClosed() {
+        XCTAssertEqual(subject.positionAboveClosed, .half)
+
+        sheetView = SheetView(view: view, configuration: SheetConfiguration(supportedPositions: [.closed, .open]))
+        subject = sheetView.layoutManager
+        XCTAssertEqual(subject.positionAboveClosed, .open)
+
+        sheetView = SheetView(view: view, configuration: SheetConfiguration(supportedPositions: [.open]))
+        subject = sheetView.layoutManager
+        XCTAssertNil(subject.positionAboveClosed)
     }
 
     /// `positionsInDirection(of:)` returns the supported positions in the direction of the translation.


### PR DESCRIPTION
Previously, the dimmed background behind the sheet would appear when the sheet was presented. And when transitioning from the top position to the next lower position, it would transition to be cleared.

This causes an issue if the sheet starts in the `half` position. The background would dim initially, but when transitioning from `half` to `open`, it would jump to 0% opacity and transition to be dimmed when fully open. And when transitioning back to `half`, the background would transition from dimmed to clear. This resulted in the initial `half` position having a dimmed background, but a clear background after opening the sheet and returning to `half`.

This introduces a change where instead of clearing the background when transitioning from the topmost position to the position below it, the background will transition to clear when the sheet moves between the position above closed and closed.

| Before | After |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/11882/184901548-40689ba5-e62d-4189-a876-965377c62e0c.mp4" /> | <video src="https://user-images.githubusercontent.com/11882/184901392-00a2392d-463e-4dab-9f49-e817d58a4846.mp4" /> |



 