### PR TITLE
Allow background views to be customized

### DIFF
--- a/Duvet/BackgroundView/BlurredSheetBackgroundView.swift
+++ b/Duvet/BackgroundView/BlurredSheetBackgroundView.swift
@@ -36,13 +36,13 @@ public class BlurredSheetBackgroundView: SheetBackgroundView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: SheetBackgroundView
+    // MARK: SheetBackground
 
-    public override func applyBackground() {
+    public func applyBackground() {
         visualEffectView.effect = blurEffect
     }
 
-    public override func clearBackground() {
+    public func clearBackground() {
         visualEffectView.effect = nil
     }
 }

--- a/Duvet/BackgroundView/DimmingSheetBackgroundView.swift
+++ b/Duvet/BackgroundView/DimmingSheetBackgroundView.swift
@@ -4,15 +4,18 @@ import UIKit
 ///
 public class DimmingSheetBackgroundView: SheetBackgroundView {
 
+    /// The alpha of the view when it is applied (dimmed). Defaults to 0.5.
+    public var alphaWhenDimmed = 0.5
+
     // MARK: Initialization
 
-    /// Initialize a `BlurredSheetBackgroundView`.
+    /// Initialize a `DimmingSheetBackgroundView`.
     ///
     /// - Parameter frame: The view's initial frame.
     ///
     public override init(frame: CGRect) {
         super.init(frame: frame)
-
+        backgroundColor = .black
         alpha = 0
     }
 
@@ -20,14 +23,13 @@ public class DimmingSheetBackgroundView: SheetBackgroundView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: SheetBackgroundView
+    // MARK: SheetBackground
 
-    public override func applyBackground() {
-        alpha = 0.5
-        backgroundColor = .black
+    public func applyBackground() {
+        alpha = alphaWhenDimmed
     }
 
-    public override func clearBackground() {
+    public func clearBackground() {
         alpha = 0
     }
 }

--- a/Duvet/BackgroundView/SheetBackgroundView.swift
+++ b/Duvet/BackgroundView/SheetBackgroundView.swift
@@ -1,15 +1,13 @@
 import UIKit
 
-/// Base class for a background view that can be applied behind the sheet. This should be overriden
-/// to apply and clear the desired background when requested.
-///
-public class SheetBackgroundView: UIView {
+public typealias SheetBackgroundView = SheetBackground & UIView
 
+public protocol SheetBackground: AnyObject {
     /// Apply the background in the view. This will be called in an animation block when the
     /// background should be shown.
-    public func applyBackground() {}
+    func applyBackground()
 
     /// Clear the background from the view. This will be called in an animation block when the
     /// background should be hidden.
-    public func clearBackground() {}
+    func clearBackground()
 }

--- a/Examples/DuvetExample/DuvetExample.xcodeproj/project.pbxproj
+++ b/Examples/DuvetExample/DuvetExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6652036628B7F1CF000C07B7 /* CustomBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6652036528B7F1CF000C07B7 /* CustomBackgroundViewController.swift */; };
 		B8788D4C2890466400C1B73B /* StatusBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8788D492890466400C1B73B /* StatusBarViewController.swift */; };
 		B8F3FD4128905A67002413A0 /* StatusBarNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F3FD3E28905A67002413A0 /* StatusBarNavigationController.swift */; };
 		C9336969219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9336968219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift */; };
@@ -45,8 +46,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6652036528B7F1CF000C07B7 /* CustomBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBackgroundViewController.swift; sourceTree = "<group>"; };
 		B8788D492890466400C1B73B /* StatusBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarViewController.swift; sourceTree = "<group>"; };
-		B8F3FD372890533E002413A0 /* Duvet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Duvet.framework; sourceTree = "<group>"; };
 		B8F3FD3E28905A67002413A0 /* StatusBarNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarNavigationController.swift; sourceTree = "<group>"; };
 		C9336968219DEA7C00AB3A4F /* BlurredBackgroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredBackgroundViewController.swift; sourceTree = "<group>"; };
 		C9496F96219B2D0C003753AC /* DuvetExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DuvetExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +155,7 @@
 				C99A872F21AF363200F8E7D2 /* KeyboardViewController.swift */,
 				C99A872621ADB09100F8E7D2 /* PushPopViewController.swift */,
 				C9A3BE6F219CC63400ED599B /* ScrollViewHeaderFooterViewController.swift */,
+				6652036528B7F1CF000C07B7 /* CustomBackgroundViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -261,6 +263,7 @@
 				C9A3BE61219CC2F700ED599B /* SheetHeaderView.swift in Sources */,
 				C982073421B1972E0032CED9 /* KeyboardFullViewController.swift in Sources */,
 				C99A872721ADB09100F8E7D2 /* PushPopViewController.swift in Sources */,
+				6652036628B7F1CF000C07B7 /* CustomBackgroundViewController.swift in Sources */,
 				C9A3BE66219CC43D00ED599B /* AdjustableContentViewController.swift in Sources */,
 				C9496F9C219B2D0C003753AC /* ViewController.swift in Sources */,
 				C9A3BE6A219CC46D00ED599B /* HalfViewController.swift in Sources */,

--- a/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController {
         case adjustable = "Adjustable"
         case adjustableWithScroll = "Adjustable with Scroll View"
         case blurredBackground = "Blurred Background"
+        case customBackground = "Custom Background"
         case half = "Half Size"
         case fittingSize = "Fitting Size"
         case fullSize = "Full Size"
@@ -30,6 +31,8 @@ class ViewController: UIViewController {
             switch self {
             case .blurredBackground:
                 return BlurredSheetBackgroundView()
+            case .customBackground:
+                return CustomSheetBackgroundView()
             default:
                 return DimmingSheetBackgroundView()
             }
@@ -43,6 +46,8 @@ class ViewController: UIViewController {
                 return AdjustableWithScrollViewController.self
             case .blurredBackground:
                 return BlurredBackgroundViewController.self
+            case .customBackground:
+                return CustomBackgroundViewController.self
             case .half:
                 return HalfViewController.self
             case .fittingSize:

--- a/Examples/DuvetExample/DuvetExample/Application/ViewControllers/CustomBackgroundViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewControllers/CustomBackgroundViewController.swift
@@ -1,0 +1,50 @@
+import Duvet
+import UIKit
+
+/// A basic sheet view that can be adjusted between the open, half and closed positions by panning
+/// on the view. The background displayed behind the sheet is custom background 
+/// Corresponds to the "Blurred Background" example.
+///
+class CustomBackgroundViewController: BaseViewController, ProvidesSheetConfiguration {
+    static let sheetConfiguration = SheetConfiguration(
+        handleConfiguration: SheetHandleConfiguration(),
+        initialPosition: .open,
+        supportedPositions: [.open, .half, .closed]
+    )
+}
+
+/// A `SheetBackgroundView` for the sheet that implements a custom background.
+///
+class CustomSheetBackgroundView: SheetBackgroundView {
+    // MARK: Initialization
+
+    /// Initialize a `CustomSheetBackgroundView`.
+    ///
+    /// - Parameter frame: The view's initial frame.
+    ///
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        alpha = 0
+
+        let gradientLayer = layer as? CAGradientLayer
+        gradientLayer?.colors = [UIColor.black.cgColor, UIColor.white.cgColor]
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override open class var layerClass: AnyClass {
+        return CAGradientLayer.classForCoder()
+    }
+
+    // MARK: SheetBackgroundView
+
+    public func applyBackground() {
+        alpha = 0.5
+    }
+
+    public func clearBackground() {
+        alpha = 0
+    }
+}


### PR DESCRIPTION
Currently, SheetBackgroundView is a public UIView that can't be overridden. This factors out a SheetBackground protocol that can be implemented by library clients to create custom views. A new example "Custom Background View" was added to the example app as a demonstration.

Also, to cover a common use case, the `alphaWhenDimmed` value on the built in DimmingSheetBackgroundView is made public.