### PR TITLE
Add main actor isolation for Swift Concurrency

### DIFF
--- a/Duvet.xcodeproj/project.pbxproj
+++ b/Duvet.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -379,6 +379,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		C9D1F68821B0826000D8FA0C /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -604,7 +605,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -631,7 +632,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.livefront.Duvet;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Duvet/BackgroundView/SheetBackgroundView.swift
+++ b/Duvet/BackgroundView/SheetBackgroundView.swift
@@ -2,6 +2,7 @@ import UIKit
 
 public typealias SheetBackgroundView = SheetBackground & UIView
 
+@MainActor
 public protocol SheetBackground: AnyObject {
     /// Apply the background in the view. This will be called in an animation block when the
     /// background should be shown.

--- a/Duvet/Configuration/SheetHandleConfiguration.swift
+++ b/Duvet/Configuration/SheetHandleConfiguration.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// Configuration parameters for controlling how a sheet's handle is displayed.
 ///
+@MainActor
 public struct SheetHandleConfiguration: Equatable {
 
     // MARK: Properties

--- a/Duvet/SheetLayoutManager.swift
+++ b/Duvet/SheetLayoutManager.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// Object that manages the constraints for moving the sheet between its supported positions.
 ///
+@MainActor
 struct SheetLayoutManager {
 
     // MARK: Properties

--- a/Duvet/SheetTransition/SheetTransitionManager.swift
+++ b/Duvet/SheetTransition/SheetTransitionManager.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// Protocol for an object that manages the transition between two sheets.
 ///
+@MainActor
 public protocol SheetTransitionManager {
 
     /// Animates the transition from one sheet view to another.

--- a/Duvet/SheetView.swift
+++ b/Duvet/SheetView.swift
@@ -50,7 +50,7 @@ public class SheetView: UIView {
 
     /// The original `UIScrollViewDelegate` on `scrollView`. Any scroll view delegate calls will be
     /// forwarded to this original delegate.
-    weak var scrollViewDelegate: UIScrollViewDelegate?
+    weak nonisolated(unsafe) var scrollViewDelegate: UIScrollViewDelegate?
 
     /// True when the sheet is being interactively moved up/down.
     var sheetInteractionInProgress = false

--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -67,7 +67,8 @@ public class SheetViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         backgroundDimmingAnimator?.stopAnimation(true)
     }
 

--- a/Duvet/SheetViewController.swift
+++ b/Duvet/SheetViewController.swift
@@ -67,11 +67,6 @@ public class SheetViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        backgroundDimmingAnimator?.stopAnimation(true)
-    }
-
     // MARK: UIViewController
 
     public override func viewDidLoad() {
@@ -104,6 +99,11 @@ public class SheetViewController: UIViewController {
         if let sheetItem = sheetItems.last, sheetItem.viewController.parent != self {
             transitionSheet(fromSheetItem: nil, toSheetItem: sheetItem, forward: true, animated: false)
         }
+    }
+
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        backgroundDimmingAnimator?.stopAnimation(true)
     }
 
     // MARK: Push/Pop Sheets

--- a/Duvet/SheetViewControllerDelegate.swift
+++ b/Duvet/SheetViewControllerDelegate.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Delegate protocol for `SheetViewController`.
 ///
+@MainActor
 public protocol SheetViewControllerDelegate: AnyObject {
 
     /// The sheet view controller should be dismissed due to a tap in the background view.

--- a/Duvet/SheetViewDelegate.swift
+++ b/Duvet/SheetViewDelegate.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Delegate protocol for `SheetView`.
 ///
+@MainActor
 protocol SheetViewDelegate: AnyObject {
 
     /// The sheet has been moved offscreen and should be dismissed.

--- a/DuvetTests/BackgroundView/BlurredSheetBackgroundViewTests.swift
+++ b/DuvetTests/BackgroundView/BlurredSheetBackgroundViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class BlurredSheetBackgroundViewTests: XCTestCase {
     var subject: BlurredSheetBackgroundView!
 

--- a/DuvetTests/BackgroundView/DimmingSheetBackgroundViewTests.swift
+++ b/DuvetTests/BackgroundView/DimmingSheetBackgroundViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class DimmingSheetBackgroundViewTests: XCTestCase {
     var subject: DimmingSheetBackgroundView!
 

--- a/DuvetTests/Configuration/SheetHandleConfigurationTests.swift
+++ b/DuvetTests/Configuration/SheetHandleConfigurationTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class SheetHandleConfigurationTests: XCTestCase {
     var subject: SheetHandleConfiguration!
 

--- a/DuvetTests/SheetContentViewTests.swift
+++ b/DuvetTests/SheetContentViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class SheetContentViewTests: XCTestCase {
     var configuration: SheetConfiguration!
     var subject: SheetContentView!

--- a/DuvetTests/SheetLayoutManagerTests.swift
+++ b/DuvetTests/SheetLayoutManagerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class SheetLayoutManagerTests: XCTestCase {
     var view: UIView!
     var sheetView: SheetView!

--- a/DuvetTests/SheetTransition/BackwardStackSheetTransitionManagerTests.swift
+++ b/DuvetTests/SheetTransition/BackwardStackSheetTransitionManagerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class BackwardStackSheetTransitionManagerTests: XCTestCase {
     var fromSheetView: SheetView!
     var toSheetView: SheetView!

--- a/DuvetTests/SheetTransition/ForwardStackSheetTarnsitionManager.swift
+++ b/DuvetTests/SheetTransition/ForwardStackSheetTarnsitionManager.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class ForwardStackSheetTransitionManagerTests: XCTestCase {
     var fromSheetView: SheetView!
     var toSheetView: SheetView!

--- a/DuvetTests/SheetViewControllerTests.swift
+++ b/DuvetTests/SheetViewControllerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class SheetViewControllerTests: XCTestCase {
     var delegate: MockSheetViewControllerDelegate!      // swiftlint:disable:this weak_delegate
     let sheetItem = SheetItem(viewController: UIViewController(), configuration: SheetConfiguration(), scrollView: nil)

--- a/DuvetTests/SheetViewTests.swift
+++ b/DuvetTests/SheetViewTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Duvet
 
+@MainActor
 class SheetViewTests: XCTestCase {
     var backgroundAnimator: UIViewPropertyAnimator!
     var configuration: SheetConfiguration!

--- a/Examples/DuvetExample/DuvetExample.xcodeproj/project.pbxproj
+++ b/Examples/DuvetExample/DuvetExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -231,6 +231,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		C9D1F68921B0836600D8FA0C /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -420,7 +421,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.livefront.DuvetExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -438,7 +439,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.livefront.DuvetExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Examples/DuvetExample/DuvetExample/Application/AppCoordinator.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/AppCoordinator.swift
@@ -1,6 +1,7 @@
 import Duvet
 import UIKit
 
+@MainActor
 protocol AppCoordinator: AnyObject {
     var rootViewController: UIViewController { get }
 
@@ -15,6 +16,7 @@ protocol AppCoordinator: AnyObject {
     func showViewController()
 }
 
+@MainActor
 class DefaultAppCoordinator {
 
     // MARK: Properites

--- a/Examples/DuvetExample/DuvetExample/Application/AppDelegate.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/AppDelegate.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let coordinator = DefaultAppCoordinator()

--- a/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewController.swift
@@ -5,6 +5,7 @@ protocol ProvidesSheetConfiguration where Self: UIViewController {
     static var sheetConfiguration: SheetConfiguration { get }
 }
 
+@MainActor
 protocol ProvidesSheetScrollView: AnyObject {
     var sheetScrollView: UIScrollView { get }
 }
@@ -27,7 +28,7 @@ class ViewController: UIViewController {
         case scrollViewHeaderFooter = "Scroll View with Header and Footer"
         case statusBar = "Custom Status Bar"
 
-        var backgroundView: SheetBackgroundView {
+        @MainActor var backgroundView: SheetBackgroundView {
             switch self {
             case .blurredBackground:
                 return BlurredSheetBackgroundView()

--- a/Examples/DuvetExample/DuvetExample/Application/ViewControllers/AdjustableWithScrollViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewControllers/AdjustableWithScrollViewController.swift
@@ -59,6 +59,7 @@ extension AdjustableWithScrollViewController: UITableViewDataSource {
         return cell
     }
 }
+
 extension AdjustableWithScrollViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         print("didSelect indexPath=\(indexPath)")
@@ -66,7 +67,7 @@ extension AdjustableWithScrollViewController: UITableViewDelegate {
 }
 
 extension AdjustableWithScrollViewController: ProvidesSheetScrollView {
-    var sheetScrollView: UIScrollView {
+    @MainActor var sheetScrollView: UIScrollView {
         return tableView
     }
 }

--- a/Examples/DuvetExample/DuvetExample/Application/ViewControllers/ScrollViewHeaderFooterViewController.swift
+++ b/Examples/DuvetExample/DuvetExample/Application/ViewControllers/ScrollViewHeaderFooterViewController.swift
@@ -124,7 +124,7 @@ extension ScrollViewHeaderFooterViewController: UITableViewDataSource {
 }
 
 extension ScrollViewHeaderFooterViewController: ProvidesSheetScrollView {
-    var sheetScrollView: UIScrollView {
+    @MainActor var sheetScrollView: UIScrollView {
         return tableView
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.0
+// swift-tools-version:6.1
 
 import PackageDescription
 
 let package = Package(
     name: "Duvet",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(name: "Duvet", targets: ["Duvet"]),
     ],


### PR DESCRIPTION
Adds `@MainActor` isolation to protocols and structs that don't already have it. In projects adopting Swift Concurrency that use Duvet, attempting to conform a main actor-isolated class to one of Duvet's protocols that is not explicitly marked as main actor-isolated will result in the following warning (and future error):

`Main actor-isolated instance method 'dismissSheetViewController()' cannot be used to satisfy nonisolated requirement from protocol 'SheetViewControllerDelegate'; this is an error in the Swift 6 language mode`

I've added a few more `@MainActor`s to other protocols (etc) as well as the test cases in order to avoid other potential issues, even though the only one we're resolving on Box Tops is with `SheetViewControllerDelegate`.